### PR TITLE
add test runs with a name not recorded in a data_files directory

### DIFF
--- a/tests/libs/actions.list.test.ts
+++ b/tests/libs/actions.list.test.ts
@@ -28,13 +28,13 @@ describe("ListAction", () => {
     const dimLockData: DimLockJSON = {
       lockFileVersion: "1.1",
       contents: [{
-        catalogResourceId: null,
-        catalogUrl: null,
-        eTag: null,
+        catalogResourceId: "dummycatalogresourceid",
+        catalogUrl: "https://www.example.com",
+        eTag: "dummyetag",
         headers: {},
         integrity: "",
         lastDownloaded: new Date("2022-01-02T03:04:05.678Z"),
-        lastModified: null,
+        lastModified: new Date("2022-01-02T03:04:05.678Z"),
         name: "test1",
         path: "./data_files/test1/dummy.txt",
         postProcesses: ["encoding-utf-8"],
@@ -71,25 +71,25 @@ describe("ListAction", () => {
     assertSpyCall(consoleLogStub, 4, {
       args: [
         "  - Catalog URL       :",
-        Colors.green("null"),
+        Colors.green("https://www.example.com"),
       ],
     });
     assertSpyCall(consoleLogStub, 5, {
       args: [
         "  - Catalog resourceid:",
-        Colors.green("null"),
+        Colors.green("dummycatalogresourceid"),
       ],
     });
     assertSpyCall(consoleLogStub, 6, {
       args: [
         "  - Last modified     :",
-        Colors.green("null"),
+        Colors.green("2022-01-02T03:04:05.678Z"),
       ],
     });
     assertSpyCall(consoleLogStub, 7, {
       args: [
         "  - ETag              :",
-        Colors.green("null"),
+        Colors.green("dummyetag"),
       ],
     });
     assertSpyCall(consoleLogStub, 8, {

--- a/tests/libs/actions.uninstall.test.ts
+++ b/tests/libs/actions.uninstall.test.ts
@@ -135,4 +135,68 @@ describe("UninstallAction", () => {
       ],
     });
   });
+
+  it("runs with a name recorded in dim.json or dim-lock.json but not exist a directory", async () => {
+    const dimData: DimJSON = {
+      fileVersion: "1.1",
+      contents: [
+        {
+          name: "test1",
+          url: "https://example.com/dummy.test",
+          catalogUrl: null,
+          catalogResourceId: null,
+          postProcesses: [],
+          headers: {},
+        },
+      ],
+    };
+    const dimLockData: DimLockJSON = {
+      lockFileVersion: "1.1",
+      contents: [{
+        catalogResourceId: null,
+        catalogUrl: null,
+        eTag: null,
+        headers: {},
+        integrity: "",
+        lastDownloaded: new Date(),
+        lastModified: null,
+        name: "test1",
+        path: "./data_files/test1/dummy.txt",
+        postProcesses: ["encoding-utf-8"],
+        url: "https://example.com/dummy.txt",
+      }],
+    };
+    await Deno.writeTextFile(
+      DEFAULT_DIM_FILE_PATH,
+      JSON.stringify(dimData, null, 2),
+    );
+    await Deno.writeTextFile(
+      DEFAULT_DIM_LOCK_FILE_PATH,
+      JSON.stringify(dimLockData, null, 2),
+    );
+    Deno.mkdirSync("data_files/example", { recursive: true });
+    Deno.writeTextFileSync("./data_files/example/dummy.txt", "dummy");
+
+    await new UninstallAction().execute(undefined as void, "test1");
+
+    assertSpyCall(consoleLogStub, 0, {
+      args: [
+        Colors.green("Removed a content from the dim.json."),
+      ],
+    });
+    assertSpyCall(consoleLogStub, 1, {
+      args: [
+        Colors.green(
+          "Removed a content from the dim-lock.json.",
+        ),
+      ],
+    });
+    assertSpyCall(consoleLogStub, 2, {
+      args: [
+        Colors.red(
+          "Failed to remove a file './data_files/test1/dummy.txt'.",
+        ),
+      ],
+    });
+  }); 
 });


### PR DESCRIPTION
Add the test to enhance the coverage of actions.ts.
This test runs with a name recorded in dim.json and dim-lock.json but not in a data_files directory
and catches the exception and displays the message which is "fail to remove a file ...".