### PR TITLE
Add dim init command to "Run the dim using Deno" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -411,6 +411,7 @@ $ cd dim
 3. Run the dim commands
 
 ```
+$ deno run -A dim.ts init
 $ deno run -A dim.ts install https://xxxxxx/data.json -n 'data_name'
 ```
 


### PR DESCRIPTION
変更理由
`deno run -A dim.ts install https://xxxxxx/data.json -n 'data_name'`実行前に
`deno run -A dim.ts init`を実行する必要があるため